### PR TITLE
Fix parse error on (||) and (&&)

### DIFF
--- a/Language/GLSL/Parser.hs
+++ b/Language/GLSL/Parser.hs
@@ -261,6 +261,9 @@ infixLeft s r = Infix (lexeme (try $ string s) >> return r) AssocLeft
 infixLeft' :: String -> (a -> a -> a) -> Operator Char S a
 infixLeft' s r = Infix (lexeme (try $ string s >> notFollowedBy (char '=')) >> return r) AssocLeft
 
+infixLeft'' :: Char -> (a -> a -> a) -> Operator Char S a
+infixLeft'' c r = Infix (lexeme (try $ char c >> notFollowedBy (oneOf (c:"="))) >> return r) AssocLeft
+
 infixRight :: String -> (a -> a -> a) -> Operator Char S a
 infixRight s r = Infix (lexeme (try $ string s) >> return r) AssocRight
 
@@ -272,9 +275,9 @@ conditionalTable =
   , [infixLeft' "<" Lt, infixLeft' ">" Gt
     ,infixLeft "<=" Lte, infixLeft ">=" Gte]
   , [infixLeft "==" Equ, infixLeft "!=" Neq]
-  , [infixLeft' "&" BitAnd]
+  , [infixLeft'' '&' BitAnd]
   , [infixLeft' "^" BitXor]
-  , [infixLeft' "|" BitOr]
+  , [infixLeft'' '|' BitOr]
   , [infixLeft "&&" And]
   , [infixLeft "||" Or]
   ]


### PR DESCRIPTION
Expressions with logical-and or logical-or did not parse before because the bitwise-or and bitwise-and matched first, putting the parser down a path that does not expect a second & or |. Examples of non-parsing expressions include:

```
true || false
4 < 2 && 5 < 1
```

This fix ensures that (&) and (|) only match if they are not followed immediately by the same character.

I think this fix could probably be refactored in some nicer way, but we are using this GLSL parser in Elm ([like this](http://elm-lang.org/edit/examples/WebGL/Thwomp.elm)) and would like to get a fix out quickly. What do you think?
