### PR TITLE
Remove unnecessary pretty dependency from .cabal file

### DIFF
--- a/language-glsl.cabal
+++ b/language-glsl.cabal
@@ -36,7 +36,6 @@ executable glsl-pprint
   build-depends:       base < 5,
                        language-glsl,
                        parsec,
-                       pretty,
                        prettyclass
   ghc-options:         -Wall
 


### PR DESCRIPTION
With ghc 7.10, language-glsl was failing to build with the error:
`    Ambiguous module name ‘Text.PrettyPrint.HughesPJClass’:
      it was found in multiple packages:
      pretty-1.1.2.0 prettyclass-1.0.0.0`

However, it seems to build fine without the 'pretty' dependency, so I suggest it be removed.