### PR TITLE
Fixes build failures with ghc-7.10

### DIFF
--- a/Language/GLSL/Parser.hs
+++ b/Language/GLSL/Parser.hs
@@ -199,14 +199,14 @@ hexadecimal = lexeme $ try $ do
   _ <- char '0'
   _ <- oneOf "Xx"
   d <- many1 hexDigit
-  m <- optionMaybe $ oneOf "Uu" -- TODO
+  _ <- optionMaybe $ oneOf "Uu" -- TODO
   return $ IntConstant Hexadecimal $ read ("0x" ++ d)
 
 octal :: P Expr
 octal = lexeme $ try $ do
   _ <- char '0'
   d <- many1 octDigit
-  m <- optionMaybe $ oneOf "Uu" -- TODO
+  _ <- optionMaybe $ oneOf "Uu" -- TODO
   return $ IntConstant Octal $ read  ("0o" ++ d)
 
 badOctal :: P ()
@@ -216,14 +216,14 @@ decimal :: P Expr
 decimal = lexeme $ try $ do
   d <- many1 digit
   notFollowedBy (char '.' <|> (exponent >> return ' '))
-  m <- optionMaybe $ oneOf "Uu" -- TODO
+  _ <- optionMaybe $ oneOf "Uu" -- TODO
   return $ IntConstant Decimal $ read d
 
 floatExponent :: P Expr
 floatExponent = lexeme $ try $ do
   d <- many1 digit
   e <- exponent
-  m <- optionMaybe $ oneOf "Ff" -- TODO
+  _ <- optionMaybe $ oneOf "Ff" -- TODO
   return $ FloatConstant $ read $ d ++ e
 
 floatPoint :: P Expr
@@ -233,7 +233,7 @@ floatPoint = lexeme $ try $ do
   d' <- many digit
   let d'' = if null d' then "0" else d'
   e <- optionMaybe exponent
-  m <- optionMaybe $ oneOf "Ff" -- TODO
+  _ <- optionMaybe $ oneOf "Ff" -- TODO
   return $ FloatConstant $ read $ d ++ "." ++ d'' ++ maybe "" id e
 
 pointFloat :: P Expr
@@ -241,7 +241,7 @@ pointFloat = lexeme $ try $ do
   _ <- char '.'
   d <- many1 digit
   e <- optionMaybe exponent
-  m <- optionMaybe $ oneOf "Ff"
+  _ <- optionMaybe $ oneOf "Ff"
   return $ FloatConstant $ read $ "0." ++ d ++ maybe "" id e
 
 exponent :: P String

--- a/Language/GLSL/Pretty.hs
+++ b/Language/GLSL/Pretty.hs
@@ -12,7 +12,7 @@ import Language.GLSL.Syntax
 
 prettyBinary :: Pretty a =>
   PrettyLevel -> Rational -> Rational -> String -> a -> a -> Doc
-prettyBinary l p op o e1 e2 = prettyParen (p > op) $
+prettyBinary l p op o e1 e2 = maybeParens (p > op) $
   pPrintPrec l op e1 <+> text o <+> pPrintPrec l op e2
 
 option :: Pretty a => Maybe a -> Doc
@@ -211,30 +211,30 @@ instance Pretty Expr where
     BoolConstant True -> text "true"
     BoolConstant False -> text "false"
   -- postfixExpression
-    Bracket e1 e2 -> prettyParen (p > 16) $
+    Bracket e1 e2 -> maybeParens (p > 16) $
       pPrintPrec l 16 e1 <> brackets (pPrint e2)
-    FieldSelection e1 f -> prettyParen (p > 16) $
+    FieldSelection e1 f -> maybeParens (p > 16) $
       pPrintPrec l 16 e1 <> char '.' <> text f
-    MethodCall e1 i ps -> prettyParen (p > 16) $
+    MethodCall e1 i ps -> maybeParens (p > 16) $
       pPrintPrec l 16 e1 <> char '.' <> pPrint i <+> parens (pPrint ps)
-    FunctionCall i ps -> prettyParen (p > 16) $
+    FunctionCall i ps -> maybeParens (p > 16) $
       pPrint i <+> parens (pPrint ps)
-    PostInc e1 -> prettyParen (p > 15) $
+    PostInc e1 -> maybeParens (p > 15) $
       pPrintPrec l 15 e1 <+> text "++"
-    PostDec e1 -> prettyParen (p > 15) $
+    PostDec e1 -> maybeParens (p > 15) $
       pPrintPrec l 15 e1 <+> text "--"
-    PreInc e1 -> prettyParen (p > 15) $
+    PreInc e1 -> maybeParens (p > 15) $
       text "++" <+> pPrintPrec l 15 e1
-    PreDec e1 -> prettyParen (p > 15) $
+    PreDec e1 -> maybeParens (p > 15) $
       text "--" <+> pPrintPrec l 15 e1
   -- unary expression
-    UnaryPlus e1 -> prettyParen (p > 15) $
+    UnaryPlus e1 -> maybeParens (p > 15) $
       text "+" <> pPrintPrec l 15 e1
-    UnaryNegate e1 -> prettyParen (p > 15) $
+    UnaryNegate e1 -> maybeParens (p > 15) $
       text "-" <> pPrintPrec l 15 e1
-    UnaryNot e1 -> prettyParen (p > 15) $
+    UnaryNot e1 -> maybeParens (p > 15) $
       text "!" <> pPrintPrec l 15 e1
-    UnaryOneComplement e1 -> prettyParen (p > 15) $
+    UnaryOneComplement e1 -> maybeParens (p > 15) $
       text "~" <> pPrintPrec l 15 e1
   -- binary expression
     Mul e1 e2 -> prettyBinary l p 14 "*" e1 e2
@@ -256,7 +256,7 @@ instance Pretty Expr where
     And e1 e2 -> prettyBinary l p 6 "&&" e1 e2
 -- TODO Xor 5 "^^"
     Or e1 e2 -> prettyBinary l p 4 "||" e1 e2
-    Selection e1 e2 e3 -> prettyParen (p > 3) $
+    Selection e1 e2 e3 -> maybeParens (p > 3) $
       pPrintPrec l 3 e1 <+> char '?' <+> pPrintPrec l 3 e2
       <+> char ':' <+> pPrintPrec l 3 e3
   -- assignment, the left Expr should be unary expression
@@ -272,7 +272,7 @@ instance Pretty Expr where
     XorAssign e1 e2 -> prettyBinary l p 2 "^=" e1 e2
     OrAssign e1 e2 -> prettyBinary l p 2 "|=" e1 e2
   -- sequence
-    Sequence e1 e2 -> prettyParen (p > 1) $
+    Sequence e1 e2 -> maybeParens (p > 1) $
       pPrintPrec l 1 e1 <> char ',' <+> pPrintPrec l 1 e2
 
 instance Pretty FunctionIdentifier where

--- a/language-glsl.cabal
+++ b/language-glsl.cabal
@@ -1,5 +1,5 @@
 name:                language-glsl
-version:             0.1.1
+version:             0.1.2
 Cabal-Version:       >= 1.8
 synopsis:            GLSL abstract syntax tree, parser, and pretty-printer
 description:
@@ -22,8 +22,8 @@ source-repository head
 
 library
   build-depends:       base < 5,
-                       parsec,
-                       prettyclass
+                       parsec >= 3.1 && < 3.2,
+                       pretty >= 1.1.2 && < 1.1.4
   ghc-options:         -Wall
   exposed-modules:     Language.GLSL,
                        Language.GLSL.Parser,
@@ -34,19 +34,18 @@ executable glsl-pprint
   main-is:             glsl-pprint.hs
   hs-source-dirs:      bin/
   build-depends:       base < 5,
-                       language-glsl,
-                       parsec,
-                       pretty,
-                       prettyclass
+                       language-glsl >= 0.1 && < 0.2,
+                       parsec >= 3.1 && < 3.2,
+                       pretty >= 1.1.2 && < 1.1.4
   ghc-options:         -Wall
 
 Test-Suite tests
   Type:            exitcode-stdio-1.0
   build-depends:   base < 5,
                    HUnit,
-                   language-glsl,
-                   parsec,
-                   prettyclass,
+                   language-glsl >= 0.1 && < 0.2,
+                   parsec >= 3.0 && < 3.2,
+                   pretty >= 1.1.2 && < 1.1.4,
                    test-framework,
                    test-framework-hunit
   ghc-options:     -Wall


### PR DESCRIPTION
The `pretty` package from version `1.1.2.0` started providing `Text.PrettyPrint.HughesPJClass` which is already provided by `prettyclass`. This causes the build to fail on ghc-7.10. However, as far as I understand, there is no need for the package to depend on `pretty`. 

So, to fix this error, either remove the dependency on `pretty` or remove dependency on `prettyclass`. As @arbn already provided a PR #9  for the first approach, this PR removes the dependency on `prettyclass` as `pretty` seems to be more actively developed. 

P.S I've no understanding on whether the `pretty` package is any better than `prettyclass` in the context of `language-glsl`.  