### PR TITLE
language-glsl.cabal: fix build failure against pretty-1.1.2.0

### DIFF
--- a/language-glsl.cabal
+++ b/language-glsl.cabal
@@ -36,7 +36,6 @@ executable glsl-pprint
   build-depends:       base < 5,
                        language-glsl,
                        parsec,
-                       pretty,
                        prettyclass
   ghc-options:         -Wall
 


### PR DESCRIPTION
pretty and prettyclass have incompatible, but clashing module names:

    Preprocessing executable 'glsl-pprint' for language-glsl-0.1.1...
    bin/glsl-pprint.hs:4:8:
        Ambiguous module name ‘Text.PrettyPrint.HughesPJClass’:
          it was found in multiple packages:
          pretty-1.1.2.0@prett_7jIfj8VCGFf1WS0tIQ1XSZ prettyclass-1.0.0.0@prett_2FbqlbOn8rU3vmeTF7SGKM

Just drop unused depend on pretty.

Signed-off-by: Sergei Trofimovich <siarheit@google.com>