### PR TITLE
Add #extension support

### DIFF
--- a/Language/GLSL/Parser.hs
+++ b/Language/GLSL/Parser.hs
@@ -460,6 +460,17 @@ declaration = choice
               semicolon
               return $ Block q i s m
          ]
+  , do _ <- keyword "#extension"
+       extensionName <- identifier
+       _ <- colon
+       behavior <-
+         choice
+            [ keyword "require" >> return ExtensionRequire
+            , keyword "enable" >> return ExtensionEnable
+            , keyword "warn" >> return ExtensionWarn
+            , keyword "disable" >> return ExtensionDisable
+            ]
+       return $ ExtensionDirective extensionName behavior
   ]
   where idecl = do
           i <- identifier

--- a/Language/GLSL/Pretty.hs
+++ b/Language/GLSL/Pretty.hs
@@ -73,7 +73,7 @@ instance Pretty Declaration where
   pPrint (Precision pq t) = text "precision" <+> pPrint pq <+> pPrint t <> semi
   pPrint (Block tq i ds n) = vcat [pPrint tq <+> text i, lbrace, nest 2 (vcat $ map pPrint ds), rbrace <+> ident n <> semi]
   pPrint (TQ tq) = pPrint tq <> semi
-  pPrint (ExtensionDirective name behavior) = text "#extension " <+> text name <+> text " : " <+> pPrint behavior
+  pPrint (ExtensionDirective name behavior) = text "#extension " <> text name <> text " : " <> pPrint behavior
 
 instance Pretty ExtensionBehavior where
   pPrint ExtensionRequire = text "require"

--- a/Language/GLSL/Pretty.hs
+++ b/Language/GLSL/Pretty.hs
@@ -73,6 +73,13 @@ instance Pretty Declaration where
   pPrint (Precision pq t) = text "precision" <+> pPrint pq <+> pPrint t <> semi
   pPrint (Block tq i ds n) = vcat [pPrint tq <+> text i, lbrace, nest 2 (vcat $ map pPrint ds), rbrace <+> ident n <> semi]
   pPrint (TQ tq) = pPrint tq <> semi
+  pPrint (ExtensionDirective name behavior) = text "#extension " <+> text name <+> text " : " <+> pPrint behavior
+
+instance Pretty ExtensionBehavior where
+  pPrint ExtensionRequire = text "require"
+  pPrint ExtensionEnable = text "enable"
+  pPrint ExtensionWarn = text "warn"
+  pPrint ExtensionDisable = text "disable"
 
 instance Pretty InitDeclarator where
   pPrint (InitDecl i a b) = text i <> indexing a <> initialize b

--- a/Language/GLSL/Syntax.hs
+++ b/Language/GLSL/Syntax.hs
@@ -51,6 +51,14 @@ data Declaration =
   | Block TypeQualifier String [Field] (Maybe (String, Maybe (Maybe Expr))) -- constant expression
 -- e.g. layout (origin_upper_left) in; TODO check if it is only used for default layout.
   | TQ TypeQualifier
+  | ExtensionDirective String ExtensionBehavior
+  deriving (Show, Eq)
+
+data ExtensionBehavior =
+  ExtensionRequire
+  | ExtensionEnable
+  | ExtensionWarn
+  | ExtensionDisable
   deriving (Show, Eq)
 
 -- TODO regroup String (Maybe (Maybe Expr)) as Declarator and use it for

--- a/glsl/sample-01.glsl
+++ b/glsl/sample-01.glsl
@@ -1,3 +1,7 @@
+#extension OES_texture_float : enable
+#extension EXT_frag_depth : require
+#extension OES_standard_derivatives : warn
+#extension WEBGL_compressed_texture_s3tc : disable
 bool success;
 bool done = false;
 int i;

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -352,7 +352,10 @@ testDeclarationsTrue =
   , "int i = (1 - 5) * 4 + 3;"
   , "int i = (1 - 5) * (4 + 3);"
   , "bool b = 1 < 2;"
-
+  , "#extension GL_EXT_frag_depth : enable"
+  , "#extension OES_texture_float :  require"
+  , "#extension OES_standard_derivatives  :  warn"
+  , "#extension  EXT_depth_clamp:disable"
   ]
 
 testDeclarationsFalse :: [String]
@@ -390,6 +393,12 @@ testDeclarationsFalse =
   , "float a[5][3];"
 -- interpolation qualifier may only preced [centroid]in/out.
 --  , "smooth const int a;"
+  , "#extension : enable"
+  , "#extension OES_texture_float  require"
+  , "#extension OES_standard_derivatives : abc"
+  , "#extension EXT_depth_clamp"
+  , "#extension 123 : require"
+  , "#extensionEXT_depth_clamp:disable"
   ]
 
 ----------------------------------------------------------------------


### PR DESCRIPTION
This PR partially solves https://github.com/noteed/language-glsl/issues/4 by adding support for extension directives (i.e. `#extension OES_texture_float : enable`)